### PR TITLE
fix: Korrigiere fabSize Attribut für erfolgreichen Build

### DIFF
--- a/GrowWaterTracker/app/src/main/res/layout/activity_main.xml
+++ b/GrowWaterTracker/app/src/main/res/layout/activity_main.xml
@@ -319,7 +319,7 @@
 		app:tint="@color/beigeBackground"
 		app:srcCompat="@drawable/ic_bucket"
 		app:elevation="8dp"
-		app:fabSize="large" />
+		app:fabSize="normal" />
 
 	<!-- Bottom Navigation with improved design -->
 	<com.google.android.material.bottomnavigation.BottomNavigationView


### PR DESCRIPTION
- Ändere fabSize von 'large' zu 'normal' (gültiger Wert)
- Behebt Android resource linking Fehler
- App kann jetzt erfolgreich kompiliert werden