### PR TITLE
fix: Korrigiere ellipse Tags in Pflanzendrawables für Android-Kompati…

### DIFF
--- a/GrowWaterTracker/app/src/main/res/drawable/plant_seedling.xml
+++ b/GrowWaterTracker/app/src/main/res/drawable/plant_seedling.xml
@@ -11,12 +11,9 @@
 		android:pathData="M15,85 L85,85 L85,100 L15,100 Z"/>
 	
 	<!-- Seed with modern design -->
-	<ellipse
+	<path
 		android:fillColor="#654321"
-		android:cx="50"
-		android:cy="88"
-		android:rx="4"
-		android:ry="2"/>
+		android:pathData="M46,88 A4,2 0 1,1 54,88 A4,2 0 1,1 46,88"/>
 	
 	<!-- Stem with modern styling -->
 	<path


### PR DESCRIPTION
…bilität

- Ersetze ellipse Tags durch path Tags mit korrekten Ellipsen-Pfaden
- Verwendet A-Befehle für Ellipsen (M46,88 A4,2 0 1,1 54,88 A4,2 0 1,1 46,88)
- Behebt Build-Fehler bei Android Resource Linking
- Alle Pflanzendrawables sind jetzt Android-kompatibel