### PR TITLE
fix: Korrigiere XML Entity Reference für & Zeichen

### DIFF
--- a/GrowWaterTracker/app/src/main/res/layout/activity_main.xml
+++ b/GrowWaterTracker/app/src/main/res/layout/activity_main.xml
@@ -353,7 +353,7 @@
 				<TextView
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:text="Designed & Developed with ❤️ by NoStudios"
+					android:text="Designed &amp; Developed with ❤️ by NoStudios"
 					android:textColor="#3498DB"
 					android:textSize="16sp"
 					android:textStyle="bold"


### PR DESCRIPTION
- Ersetze & durch &amp; in activity_main.xml
- Behebt Build-Fehler 'The entity name must immediately follow the & in the entity reference'
- XML-Parsing funktioniert jetzt korrekt